### PR TITLE
Split famous algorithms into standalone demos

### DIFF
--- a/algorithms/a_star_search.py
+++ b/algorithms/a_star_search.py
@@ -1,0 +1,40 @@
+from typing import Dict, List, Tuple, Callable, Optional
+import heapq
+
+
+def a_star_search(
+    graph: Dict[int, List[Tuple[int, int]]],
+    start: int,
+    goal: int,
+    heuristic: Callable[[int], int]
+) -> Optional[List[int]]:
+    open_set = [(heuristic(start), 0, start, [])]
+    visited = set()
+    while open_set:
+        est, cost, node, path = heapq.heappop(open_set)
+        if node in visited:
+            continue
+        path = path + [node]
+        if node == goal:
+            return path
+        visited.add(node)
+        for neigh, weight in graph.get(node, []):
+            if neigh not in visited:
+                new_cost = cost + weight
+                heapq.heappush(open_set, (new_cost + heuristic(neigh), new_cost, neigh, path))
+    return None
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 1), (2, 3)],
+        1: [(3, 1)],
+        2: [(3, 1)],
+        3: []
+    }
+    heuristic = lambda x: 0
+    print("A* path:", a_star_search(graph, 0, 3, heuristic))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/bellman_ford.py
+++ b/algorithms/bellman_ford.py
@@ -1,0 +1,33 @@
+from collections import defaultdict
+from typing import Dict, List, Tuple, Optional
+import math
+
+
+def bellman_ford(graph: Dict[int, List[Tuple[int, int]]], start: int) -> Optional[Dict[int, float]]:
+    dist = defaultdict(lambda: math.inf)
+    dist[start] = 0
+    vertices = list(graph.keys())
+    for _ in range(len(vertices) - 1):
+        for v in vertices:
+            for u, w in graph.get(v, []):
+                if dist[v] + w < dist[u]:
+                    dist[u] = dist[v] + w
+    for v in vertices:
+        for u, w in graph.get(v, []):
+            if dist[v] + w < dist[u]:
+                return None
+    return dict(dist)
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 1), (2, 4)],
+        1: [(2, -3), (3, 2)],
+        2: [(3, 3)],
+        3: []
+    }
+    print("Bellman-Ford:", bellman_ford(graph, 0))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/bfs.py
+++ b/algorithms/bfs.py
@@ -1,0 +1,31 @@
+from collections import deque
+from typing import Dict, List, Tuple
+
+# Graph is represented as adjacency list {node: [(neighbor, weight), ...]}
+
+def bfs(graph: Dict[int, List[Tuple[int, int]]], start: int) -> List[int]:
+    visited = set([start])
+    order = []
+    queue = deque([start])
+    while queue:
+        v = queue.popleft()
+        order.append(v)
+        for u, _ in graph.get(v, []):
+            if u not in visited:
+                visited.add(u)
+                queue.append(u)
+    return order
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 1), (2, 1)],
+        1: [(3, 1)],
+        2: [(3, 1)],
+        3: []
+    }
+    print("BFS order:", bfs(graph, 0))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/binary_search.py
+++ b/algorithms/binary_search.py
@@ -1,0 +1,26 @@
+from typing import List
+
+
+def binary_search(arr: List[int], target: int) -> int:
+    """Return index of target in sorted arr or -1 if not found."""
+    left, right = 0, len(arr) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        if arr[mid] == target:
+            return mid
+        if arr[mid] < target:
+            left = mid + 1
+        else:
+            right = mid - 1
+    return -1
+
+
+def main() -> None:
+    arr = [1, 3, 5, 7, 9, 11]
+    target = 7
+    print(f"Array: {arr}")
+    print(f"Searching for {target}: index {binary_search(arr, target)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/bubble_sort.py
+++ b/algorithms/bubble_sort.py
@@ -1,0 +1,21 @@
+from typing import List
+
+
+def bubble_sort(arr: List[int]) -> List[int]:
+    a = arr[:]
+    n = len(a)
+    for i in range(n):
+        for j in range(0, n - i - 1):
+            if a[j] > a[j + 1]:
+                a[j], a[j + 1] = a[j + 1], a[j]
+    return a
+
+
+def main() -> None:
+    arr = [5, 1, 4, 2, 8]
+    print(f"Original: {arr}")
+    print(f"Sorted:   {bubble_sort(arr)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/dfs.py
+++ b/algorithms/dfs.py
@@ -1,0 +1,30 @@
+from typing import Dict, List, Tuple
+
+
+def dfs(graph: Dict[int, List[Tuple[int, int]]], start: int) -> List[int]:
+    visited = set()
+    order = []
+
+    def _dfs(v: int) -> None:
+        visited.add(v)
+        order.append(v)
+        for u, _ in graph.get(v, []):
+            if u not in visited:
+                _dfs(u)
+
+    _dfs(start)
+    return order
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 1), (2, 1)],
+        1: [(3, 1)],
+        2: [(3, 1)],
+        3: []
+    }
+    print("DFS order:", dfs(graph, 0))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/dijkstra.py
+++ b/algorithms/dijkstra.py
@@ -1,0 +1,34 @@
+from collections import defaultdict
+from typing import Dict, List, Tuple
+import heapq
+import math
+
+
+def dijkstra(graph: Dict[int, List[Tuple[int, int]]], start: int) -> Dict[int, float]:
+    dist = defaultdict(lambda: math.inf)
+    dist[start] = 0
+    pq = [(0, start)]
+    while pq:
+        d, v = heapq.heappop(pq)
+        if d > dist[v]:
+            continue
+        for u, w in graph.get(v, []):
+            nd = d + w
+            if nd < dist[u]:
+                dist[u] = nd
+                heapq.heappush(pq, (nd, u))
+    return dict(dist)
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 4), (2, 1)],
+        1: [(3, 1)],
+        2: [(1, 2), (3, 5)],
+        3: []
+    }
+    print("Shortest paths:", dijkstra(graph, 0))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/floyd_warshall.py
+++ b/algorithms/floyd_warshall.py
@@ -1,0 +1,28 @@
+from typing import List
+
+
+def floyd_warshall(matrix: List[List[int]]) -> List[List[int]]:
+    n = len(matrix)
+    dist = [row[:] for row in matrix]
+    for k in range(n):
+        for i in range(n):
+            for j in range(n):
+                if dist[i][k] + dist[k][j] < dist[i][j]:
+                    dist[i][j] = dist[i][k] + dist[k][j]
+    return dist
+
+
+def main() -> None:
+    INF = 99999
+    matrix = [
+        [0, 5, INF, 10],
+        [INF, 0, 3, INF],
+        [INF, INF, 0, 1],
+        [INF, INF, INF, 0]
+    ]
+    for row in floyd_warshall(matrix):
+        print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/heap_sort.py
+++ b/algorithms/heap_sort.py
@@ -1,0 +1,18 @@
+from typing import List
+import heapq
+
+
+def heap_sort(arr: List[int]) -> List[int]:
+    a = arr[:]
+    heapq.heapify(a)
+    return [heapq.heappop(a) for _ in range(len(a))]
+
+
+def main() -> None:
+    arr = [12, 11, 13, 5, 6, 7]
+    print(f"Original: {arr}")
+    print(f"Sorted:   {heap_sort(arr)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/insertion_sort.py
+++ b/algorithms/insertion_sort.py
@@ -1,0 +1,23 @@
+from typing import List
+
+
+def insertion_sort(arr: List[int]) -> List[int]:
+    a = arr[:]
+    for i in range(1, len(a)):
+        key = a[i]
+        j = i - 1
+        while j >= 0 and a[j] > key:
+            a[j + 1] = a[j]
+            j -= 1
+        a[j + 1] = key
+    return a
+
+
+def main() -> None:
+    arr = [5, 2, 4, 6, 1, 3]
+    print(f"Original: {arr}")
+    print(f"Sorted:   {insertion_sort(arr)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/kmp_search.py
+++ b/algorithms/kmp_search.py
@@ -1,0 +1,33 @@
+from typing import List
+
+
+def kmp_search(text: str, pattern: str) -> int:
+    if not pattern:
+        return 0
+    lps: List[int] = [0] * len(pattern)
+    j = 0
+    for i in range(1, len(pattern)):
+        while j > 0 and pattern[i] != pattern[j]:
+            j = lps[j - 1]
+        if pattern[i] == pattern[j]:
+            j += 1
+            lps[i] = j
+    j = 0
+    for i in range(len(text)):
+        while j > 0 and text[i] != pattern[j]:
+            j = lps[j - 1]
+        if text[i] == pattern[j]:
+            j += 1
+            if j == len(pattern):
+                return i - j + 1
+    return -1
+
+
+def main() -> None:
+    text = "abxabcabcaby"
+    pattern = "abcaby"
+    print(f"Pattern found at index {kmp_search(text, pattern)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/kosaraju_scc.py
+++ b/algorithms/kosaraju_scc.py
@@ -1,0 +1,52 @@
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+
+def kosaraju_scc(graph: Dict[int, List[Tuple[int, int]]]) -> List[List[int]]:
+    visited = set()
+    order: List[int] = []
+
+    def dfs1(v: int) -> None:
+        visited.add(v)
+        for u, _ in graph.get(v, []):
+            if u not in visited:
+                dfs1(u)
+        order.append(v)
+
+    def dfs2(v: int, component: List[int], gr: Dict[int, List[Tuple[int, int]]]) -> None:
+        component.append(v)
+        visited.add(v)
+        for u, _ in gr.get(v, []):
+            if u not in visited:
+                dfs2(u, component, gr)
+
+    for v in graph:
+        if v not in visited:
+            dfs1(v)
+    gr: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+    for v in graph:
+        for u, w in graph[v]:
+            gr[u].append((v, w))
+    visited.clear()
+    sccs = []
+    for v in reversed(order):
+        if v not in visited:
+            comp: List[int] = []
+            dfs2(v, comp, gr)
+            sccs.append(comp)
+    return sccs
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 1)],
+        1: [(2, 1)],
+        2: [(0, 1), (3, 1)],
+        3: [(4, 1)],
+        4: []
+    }
+    print("Kosaraju SCCs:", kosaraju_scc(graph))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/kruskal_mst.py
+++ b/algorithms/kruskal_mst.py
@@ -1,0 +1,47 @@
+from typing import List, Tuple
+
+
+def kruskal_mst(vertices: List[int], edges: List[Tuple[int, int, int]]) -> List[Tuple[int, int, int]]:
+    parent = {v: v for v in vertices}
+    rank = {v: 0 for v in vertices}
+
+    def find(v: int) -> int:
+        while parent[v] != v:
+            parent[v] = parent[parent[v]]
+            v = parent[v]
+        return v
+
+    def union(u: int, v: int) -> bool:
+        ru, rv = find(u), find(v)
+        if ru == rv:
+            return False
+        if rank[ru] < rank[rv]:
+            parent[ru] = rv
+        elif rank[ru] > rank[rv]:
+            parent[rv] = ru
+        else:
+            parent[rv] = ru
+            rank[ru] += 1
+        return True
+
+    mst = []
+    for u, v, w in sorted(edges, key=lambda x: x[2]):
+        if union(u, v):
+            mst.append((u, v, w))
+    return mst
+
+
+def main() -> None:
+    vertices = [0, 1, 2, 3]
+    edges = [
+        (0, 1, 10),
+        (0, 2, 6),
+        (0, 3, 5),
+        (1, 3, 15),
+        (2, 3, 4)
+    ]
+    print("Kruskal MST:", kruskal_mst(vertices, edges))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/longest_common_subsequence.py
+++ b/algorithms/longest_common_subsequence.py
@@ -1,0 +1,23 @@
+from typing import List
+
+
+def longest_common_subsequence(a: str, b: str) -> str:
+    m, n = len(a), len(b)
+    dp: List[List[str]] = [["" for _ in range(n + 1)] for _ in range(m + 1)]
+    for i in range(m):
+        for j in range(n):
+            if a[i] == b[j]:
+                dp[i + 1][j + 1] = dp[i][j] + a[i]
+            else:
+                dp[i + 1][j + 1] = max(dp[i][j + 1], dp[i + 1][j], key=len)
+    return dp[m][n]
+
+
+def main() -> None:
+    a = "AGGTAB"
+    b = "GXTXAYB"
+    print("LCS:", longest_common_subsequence(a, b))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/merge_sort.py
+++ b/algorithms/merge_sort.py
@@ -1,0 +1,35 @@
+from typing import List
+
+
+def merge_sort(arr: List[int]) -> List[int]:
+    if len(arr) <= 1:
+        return arr
+    mid = len(arr) // 2
+    left = merge_sort(arr[:mid])
+    right = merge_sort(arr[mid:])
+    return merge(left, right)
+
+
+def merge(left: List[int], right: List[int]) -> List[int]:
+    result = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    result.extend(left[i:])
+    result.extend(right[j:])
+    return result
+
+
+def main() -> None:
+    arr = [38, 27, 43, 3, 9, 82, 10]
+    print(f"Original: {arr}")
+    print(f"Sorted:   {merge_sort(arr)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/prim_mst.py
+++ b/algorithms/prim_mst.py
@@ -1,0 +1,39 @@
+from typing import Dict, List, Tuple
+import heapq
+
+
+def prim_mst(graph: Dict[int, List[Tuple[int, int]]], start: int = 0) -> List[Tuple[int, int, int]]:
+    visited = set([start])
+    pq = []
+    for u, w in graph.get(start, []):
+        heapq.heappush(pq, (w, start, u))
+    mst = []
+    while pq:
+        w, v, u = heapq.heappop(pq)
+        if u in visited:
+            continue
+        visited.add(u)
+        mst.append((v, u, w))
+        for nxt, wt in graph.get(u, []):
+            if nxt not in visited:
+                heapq.heappush(pq, (wt, u, nxt))
+    return mst
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 4), (7, 8)],
+        1: [(2, 8), (7, 11)],
+        2: [(3, 7), (5, 4), (8, 2)],
+        3: [(4, 9), (5, 14)],
+        4: [(5, 10)],
+        5: [(6, 2)],
+        6: [(7, 1), (8, 6)],
+        7: [(8, 7)],
+        8: []
+    }
+    print("Prim MST:", prim_mst(graph, 0))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/quick_select.py
+++ b/algorithms/quick_select.py
@@ -1,0 +1,26 @@
+import random
+from typing import List
+
+
+def quick_select(arr: List[int], k: int) -> int:
+    if not 1 <= k <= len(arr):
+        raise ValueError("k out of range")
+    pivot = random.choice(arr)
+    lows = [x for x in arr if x < pivot]
+    highs = [x for x in arr if x > pivot]
+    pivots = [x for x in arr if x == pivot]
+    if k <= len(lows):
+        return quick_select(lows, k)
+    if k <= len(lows) + len(pivots):
+        return pivot
+    return quick_select(highs, k - len(lows) - len(pivots))
+
+
+def main() -> None:
+    arr = [7, 10, 4, 3, 20, 15]
+    k = 3
+    print(f"{k}rd smallest element is {quick_select(arr, k)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/quick_sort.py
+++ b/algorithms/quick_sort.py
@@ -1,0 +1,21 @@
+from typing import List
+
+
+def quick_sort(arr: List[int]) -> List[int]:
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quick_sort(left) + middle + quick_sort(right)
+
+
+def main() -> None:
+    arr = [10, 7, 8, 9, 1, 5]
+    print(f"Original: {arr}")
+    print(f"Sorted:   {quick_sort(arr)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/selection_sort.py
+++ b/algorithms/selection_sort.py
@@ -1,0 +1,22 @@
+from typing import List
+
+
+def selection_sort(arr: List[int]) -> List[int]:
+    a = arr[:]
+    for i in range(len(a)):
+        min_idx = i
+        for j in range(i + 1, len(a)):
+            if a[j] < a[min_idx]:
+                min_idx = j
+        a[i], a[min_idx] = a[min_idx], a[i]
+    return a
+
+
+def main() -> None:
+    arr = [64, 25, 12, 22, 11]
+    print(f"Original: {arr}")
+    print(f"Sorted:   {selection_sort(arr)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/tarjan_scc.py
+++ b/algorithms/tarjan_scc.py
@@ -1,0 +1,55 @@
+from typing import Dict, List, Tuple
+
+
+def tarjan_scc(graph: Dict[int, List[Tuple[int, int]]]) -> List[List[int]]:
+    index = 0
+    stack = []
+    indices = {}
+    lowlink = {}
+    on_stack = set()
+    sccs = []
+
+    def strongconnect(v: int) -> None:
+        nonlocal index
+        indices[v] = index
+        lowlink[v] = index
+        index += 1
+        stack.append(v)
+        on_stack.add(v)
+
+        for w, _ in graph.get(v, []):
+            if w not in indices:
+                strongconnect(w)
+                lowlink[v] = min(lowlink[v], lowlink[w])
+            elif w in on_stack:
+                lowlink[v] = min(lowlink[v], indices[w])
+
+        if lowlink[v] == indices[v]:
+            component = []
+            while True:
+                w = stack.pop()
+                on_stack.remove(w)
+                component.append(w)
+                if w == v:
+                    break
+            sccs.append(component)
+
+    for v in graph:
+        if v not in indices:
+            strongconnect(v)
+    return sccs
+
+
+def main() -> None:
+    graph = {
+        0: [(1, 1)],
+        1: [(2, 1)],
+        2: [(0, 1), (3, 1)],
+        3: [(4, 1)],
+        4: []
+    }
+    print("Tarjan SCCs:", tarjan_scc(graph))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/topological_sort.py
+++ b/algorithms/topological_sort.py
@@ -1,0 +1,37 @@
+from collections import defaultdict, deque
+from typing import Dict, List, Tuple
+
+
+def topological_sort(graph: Dict[int, List[Tuple[int, int]]]) -> List[int]:
+    indeg = defaultdict(int)
+    for v in graph:
+        for u, _ in graph[v]:
+            indeg[u] += 1
+    queue = deque([v for v in graph if indeg[v] == 0])
+    order = []
+    while queue:
+        v = queue.popleft()
+        order.append(v)
+        for u, _ in graph.get(v, []):
+            indeg[u] -= 1
+            if indeg[u] == 0:
+                queue.append(u)
+    if len(order) != len(graph):
+        raise ValueError("Graph has a cycle")
+    return order
+
+
+def main() -> None:
+    graph = {
+        5: [(2, 1), (0, 1)],
+        4: [(0, 1), (1, 1)],
+        2: [(3, 1)],
+        3: [(1, 1)],
+        1: [],
+        0: []
+    }
+    print("Topological order:", topological_sort(graph))
+
+
+if __name__ == "__main__":
+    main()

--- a/famous_algorithms.py
+++ b/famous_algorithms.py
@@ -1,0 +1,410 @@
+# Collection of classic algorithm implementations in Python.
+# Each function demonstrates a standard algorithm for reference and teaching.
+
+from collections import defaultdict, deque
+import heapq
+import math
+import random
+
+# 1. Binary Search
+
+def binary_search(arr, target):
+    """Return index of target in sorted arr or -1 if not found."""
+    left, right = 0, len(arr) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        if arr[mid] == target:
+            return mid
+        if arr[mid] < target:
+            left = mid + 1
+        else:
+            right = mid - 1
+    return -1
+
+# 2. Bubble Sort
+
+def bubble_sort(arr):
+    a = arr[:]
+    n = len(a)
+    for i in range(n):
+        for j in range(0, n - i - 1):
+            if a[j] > a[j + 1]:
+                a[j], a[j + 1] = a[j + 1], a[j]
+    return a
+
+# 3. Insertion Sort
+
+def insertion_sort(arr):
+    a = arr[:]
+    for i in range(1, len(a)):
+        key = a[i]
+        j = i - 1
+        while j >= 0 and a[j] > key:
+            a[j + 1] = a[j]
+            j -= 1
+        a[j + 1] = key
+    return a
+
+# 4. Selection Sort
+
+def selection_sort(arr):
+    a = arr[:]
+    for i in range(len(a)):
+        min_idx = i
+        for j in range(i + 1, len(a)):
+            if a[j] < a[min_idx]:
+                min_idx = j
+        a[i], a[min_idx] = a[min_idx], a[i]
+    return a
+
+# 5. Merge Sort
+
+def merge_sort(arr):
+    if len(arr) <= 1:
+        return arr
+    mid = len(arr) // 2
+    left = merge_sort(arr[:mid])
+    right = merge_sort(arr[mid:])
+    return merge(left, right)
+
+def merge(left, right):
+    result = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    result.extend(left[i:])
+    result.extend(right[j:])
+    return result
+
+# 6. Quick Sort
+
+def quick_sort(arr):
+    if len(arr) <= 1:
+        return arr
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    return quick_sort(left) + middle + quick_sort(right)
+
+# 7. Heap Sort
+
+def heap_sort(arr):
+    a = arr[:]
+    heapq.heapify(a)
+    return [heapq.heappop(a) for _ in range(len(a))]
+
+# Graph algorithms assume graph is given as adjacency list: {node: [(neighbor, weight), ...]}
+
+# 8. Breadth-First Search
+
+def bfs(graph, start):
+    visited = set([start])
+    order = []
+    queue = deque([start])
+    while queue:
+        v = queue.popleft()
+        order.append(v)
+        for u, _ in graph.get(v, []):
+            if u not in visited:
+                visited.add(u)
+                queue.append(u)
+    return order
+
+# 9. Depth-First Search
+
+def dfs(graph, start):
+    visited = set()
+    order = []
+    def _dfs(v):
+        visited.add(v)
+        order.append(v)
+        for u, _ in graph.get(v, []):
+            if u not in visited:
+                _dfs(u)
+    _dfs(start)
+    return order
+
+# 10. Dijkstra's Shortest Path
+
+def dijkstra(graph, start):
+    dist = defaultdict(lambda: math.inf)
+    dist[start] = 0
+    pq = [(0, start)]
+    while pq:
+        d, v = heapq.heappop(pq)
+        if d > dist[v]:
+            continue
+        for u, w in graph.get(v, []):
+            nd = d + w
+            if nd < dist[u]:
+                dist[u] = nd
+                heapq.heappush(pq, (nd, u))
+    return dict(dist)
+
+# 11. Bellman-Ford Algorithm
+
+def bellman_ford(graph, start):
+    # graph is dict of {node: [(neighbor, weight), ...]}
+    dist = defaultdict(lambda: math.inf)
+    dist[start] = 0
+    vertices = list(graph.keys())
+    for _ in range(len(vertices) - 1):
+        for v in vertices:
+            for u, w in graph.get(v, []):
+                if dist[v] + w < dist[u]:
+                    dist[u] = dist[v] + w
+    # Check for negative cycles
+    for v in vertices:
+        for u, w in graph.get(v, []):
+            if dist[v] + w < dist[u]:
+                return None  # Negative cycle detected
+    return dict(dist)
+
+# 12. Floyd-Warshall Algorithm
+
+def floyd_warshall(matrix):
+    n = len(matrix)
+    dist = [row[:] for row in matrix]
+    for k in range(n):
+        for i in range(n):
+            for j in range(n):
+                if dist[i][k] + dist[k][j] < dist[i][j]:
+                    dist[i][j] = dist[i][k] + dist[k][j]
+    return dist
+
+# 13. Prim's Minimum Spanning Tree
+
+def prim_mst(graph, start=0):
+    visited = set([start])
+    edges = []
+    pq = []
+    for u, w in graph.get(start, []):
+        heapq.heappush(pq, (w, start, u))
+    mst = []
+    while pq:
+        w, v, u = heapq.heappop(pq)
+        if u in visited:
+            continue
+        visited.add(u)
+        mst.append((v, u, w))
+        for nxt, wt in graph.get(u, []):
+            if nxt not in visited:
+                heapq.heappush(pq, (wt, u, nxt))
+    return mst
+
+# 14. Kruskal's Minimum Spanning Tree
+
+def kruskal_mst(vertices, edges):
+    parent = {v: v for v in vertices}
+    rank = {v: 0 for v in vertices}
+
+    def find(v):
+        while parent[v] != v:
+            parent[v] = parent[parent[v]]
+            v = parent[v]
+        return v
+
+    def union(u, v):
+        ru, rv = find(u), find(v)
+        if ru == rv:
+            return False
+        if rank[ru] < rank[rv]:
+            parent[ru] = rv
+        elif rank[ru] > rank[rv]:
+            parent[rv] = ru
+        else:
+            parent[rv] = ru
+            rank[ru] += 1
+        return True
+
+    mst = []
+    for u, v, w in sorted(edges, key=lambda x: x[2]):
+        if union(u, v):
+            mst.append((u, v, w))
+    return mst
+
+# 15. Topological Sort (Kahn's algorithm)
+
+def topological_sort(graph):
+    indeg = defaultdict(int)
+    for v in graph:
+        for u, _ in graph[v]:
+            indeg[u] += 1
+    queue = deque([v for v in graph if indeg[v] == 0])
+    order = []
+    while queue:
+        v = queue.popleft()
+        order.append(v)
+        for u, _ in graph.get(v, []):
+            indeg[u] -= 1
+            if indeg[u] == 0:
+                queue.append(u)
+    if len(order) != len(graph):
+        raise ValueError("Graph has a cycle")
+    return order
+
+# 16. Knuth-Morris-Pratt (KMP) pattern search
+
+def kmp_search(text, pattern):
+    if not pattern:
+        return 0
+    lps = [0] * len(pattern)
+    j = 0
+    for i in range(1, len(pattern)):
+        while j > 0 and pattern[i] != pattern[j]:
+            j = lps[j - 1]
+        if pattern[i] == pattern[j]:
+            j += 1
+            lps[i] = j
+    j = 0
+    for i in range(len(text)):
+        while j > 0 and text[i] != pattern[j]:
+            j = lps[j - 1]
+        if text[i] == pattern[j]:
+            j += 1
+            if j == len(pattern):
+                return i - j + 1
+    return -1
+
+# 17. Longest Common Subsequence (LCS)
+
+def longest_common_subsequence(a, b):
+    m, n = len(a), len(b)
+    dp = [["" for _ in range(n + 1)] for _ in range(m + 1)]
+    for i in range(m):
+        for j in range(n):
+            if a[i] == b[j]:
+                dp[i + 1][j + 1] = dp[i][j] + a[i]
+            else:
+                dp[i + 1][j + 1] = max(dp[i][j + 1], dp[i + 1][j], key=len)
+    return dp[m][n]
+
+# 18. Quick Select (k-th smallest)
+
+def quick_select(arr, k):
+    if not 1 <= k <= len(arr):
+        raise ValueError("k out of range")
+    pivot = random.choice(arr)
+    lows = [x for x in arr if x < pivot]
+    highs = [x for x in arr if x > pivot]
+    pivots = [x for x in arr if x == pivot]
+    if k <= len(lows):
+        return quick_select(lows, k)
+    if k <= len(lows) + len(pivots):
+        return pivot
+    return quick_select(highs, k - len(lows) - len(pivots))
+
+# 19. Tarjan's Strongly Connected Components
+
+def tarjan_scc(graph):
+    index = 0
+    stack = []
+    indices = {}
+    lowlink = {}
+    on_stack = set()
+    sccs = []
+
+    def strongconnect(v):
+        nonlocal index
+        indices[v] = index
+        lowlink[v] = index
+        index += 1
+        stack.append(v)
+        on_stack.add(v)
+
+        for w, _ in graph.get(v, []):
+            if w not in indices:
+                strongconnect(w)
+                lowlink[v] = min(lowlink[v], lowlink[w])
+            elif w in on_stack:
+                lowlink[v] = min(lowlink[v], indices[w])
+
+        if lowlink[v] == indices[v]:
+            component = []
+            while True:
+                w = stack.pop()
+                on_stack.remove(w)
+                component.append(w)
+                if w == v:
+                    break
+            sccs.append(component)
+
+    for v in graph:
+        if v not in indices:
+            strongconnect(v)
+    return sccs
+
+# 20. Kosaraju's Strongly Connected Components
+
+def kosaraju_scc(graph):
+    visited = set()
+    order = []
+
+    def dfs1(v):
+        visited.add(v)
+        for u, _ in graph.get(v, []):
+            if u not in visited:
+                dfs1(u)
+        order.append(v)
+
+    def dfs2(v, component, gr):
+        component.append(v)
+        visited.add(v)
+        for u, _ in gr.get(v, []):
+            if u not in visited:
+                dfs2(u, component, gr)
+
+    for v in graph:
+        if v not in visited:
+            dfs1(v)
+    gr = defaultdict(list)
+    for v in graph:
+        for u, w in graph[v]:
+            gr[u].append((v, w))
+    visited.clear()
+    sccs = []
+    for v in reversed(order):
+        if v not in visited:
+            comp = []
+            dfs2(v, comp, gr)
+            sccs.append(comp)
+    return sccs
+
+# 21. A* Search
+
+def a_star_search(graph, start, goal, heuristic):
+    open_set = [(heuristic(start), 0, start, [])]
+    visited = set()
+    while open_set:
+        est, cost, node, path = heapq.heappop(open_set)
+        if node in visited:
+            continue
+        path = path + [node]
+        if node == goal:
+            return path
+        visited.add(node)
+        for neigh, weight in graph.get(node, []):
+            if neigh not in visited:
+                new_cost = cost + weight
+                heapq.heappush(open_set, (new_cost + heuristic(neigh), new_cost, neigh, path))
+    return None
+
+if __name__ == "__main__":
+    # Simple usage demonstration
+    arr = [5, 2, 9, 1, 5, 6]
+    print("quick_sort:", quick_sort(arr))
+    print("binary_search 5:", binary_search(sorted(arr), 5))
+    graph = {
+        0: [(1, 4), (2, 1)],
+        1: [(3, 1)],
+        2: [(1, 2), (3, 5)],
+        3: []
+    }
+    print("dijkstra:", dijkstra(graph, 0))
+


### PR DESCRIPTION
## Summary
- create an `algorithms` directory
- split the algorithms from `famous_algorithms.py` into 21 individual modules
- each module has a `main()` function demonstrating its algorithm on a small example

## Testing
- `for file in algorithms/*.py; do python3 "$file"; done`
- `python3 huffman_coding.py`
- `python3 Simulated_Annealing_TSP.py` *(fails: requires matplotlib)*

------
https://chatgpt.com/codex/tasks/task_b_683c8661e5dc832aabdbef22dfd51421